### PR TITLE
Show/hide adapter base on other item

### DIFF
--- a/app/src/main/java/com/carousell/soloadapter/sample/MainActivity.kt
+++ b/app/src/main/java/com/carousell/soloadapter/sample/MainActivity.kt
@@ -12,8 +12,12 @@ import kotlinx.android.synthetic.main.activity_main.*
 class MainActivity : AppCompatActivity() {
 
     private val dynamicAdapters = (1..100).map {
-        dynamicBindAdapter(it + 1)
+        dynamicBindAdapter("Click to hide $it")
     }
+    private val fakeTitleAdapter =
+        dynamicBindAdapter("Show/hide base on #3 of item", clickToHide = false).also {
+            it.bindAdapter(dynamicAdapters[2])
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,6 +30,7 @@ class MainActivity : AppCompatActivity() {
         )
         recyclerView.adapter = adapter
 
+        adapter.addAdapter(fakeTitleAdapter)
         dynamicAdapters.forEach {
             adapter.addAdapter(it)
         }
@@ -44,13 +49,14 @@ class MainActivity : AppCompatActivity() {
         return SoloAdapter(view)
     }
 
-    private fun dynamicBindAdapter(index: Int): SoloAdapter {
-        val data = "Click to hide $index"
+    private fun dynamicBindAdapter(data: String, clickToHide: Boolean = true): SoloAdapter {
         val adapter = SoloAdapter(R.layout.layout_text)
         adapter.bind { view ->
             view.findViewById<TextView>(R.id.textView).text = data
-            view.setOnClickListener {
-                adapter.setShown(false)
+            if (clickToHide) {
+                view.setOnClickListener {
+                    adapter.setShown(false)
+                }
             }
         }
         return adapter

--- a/soloadapter/src/main/java/com/carousell/soloadapter/SoloAdapter.kt
+++ b/soloadapter/src/main/java/com/carousell/soloadapter/SoloAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 
 class SoloAdapter : RecyclerView.Adapter<SoloAdapter.ViewHolder> {
     @LayoutRes
@@ -12,6 +13,33 @@ class SoloAdapter : RecyclerView.Adapter<SoloAdapter.ViewHolder> {
     private var view: View? = null
     private var shown: Boolean = true
     private var bindFunction: ((itemView: View) -> Unit)? = null
+
+    private var bindAdapter: RecyclerView.Adapter<out RecyclerView.ViewHolder>? = null
+    private val bindAdapterDataObserver = object : AdapterDataObserver() {
+        override fun onChanged() {
+            checkBindAdapterVisibility()
+        }
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+            checkBindAdapterVisibility()
+        }
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int, payload: Any?) {
+            checkBindAdapterVisibility()
+        }
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            checkBindAdapterVisibility()
+        }
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+            checkBindAdapterVisibility()
+        }
+
+        override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
+            checkBindAdapterVisibility()
+        }
+    }
 
     constructor(view: View) : super() {
         this.view = view
@@ -23,6 +51,26 @@ class SoloAdapter : RecyclerView.Adapter<SoloAdapter.ViewHolder> {
 
     fun bind(bindFunction: (itemView: View) -> Unit) {
         this.bindFunction = bindFunction
+    }
+
+    fun checkBindAdapterVisibility() {
+        bindAdapter?.let { target ->
+            if (target.itemCount > 0 && !shown) {
+                setShown(true)
+            } else if (target.itemCount == 0 && shown) {
+                setShown(false)
+            }
+        }
+    }
+
+    fun bindAdapter(target: RecyclerView.Adapter<out RecyclerView.ViewHolder>) {
+        bindAdapter = target
+        target.registerAdapterDataObserver(bindAdapterDataObserver)
+    }
+
+    fun unBindAdapter(target: RecyclerView.Adapter<out RecyclerView.ViewHolder>) {
+        target.unregisterAdapterDataObserver(bindAdapterDataObserver)
+        bindAdapter = null
     }
 
     fun setShown(isShown: Boolean) {


### PR DESCRIPTION
For title/footer purpose it usually we have to bind with other adapter to determine if the header/footer should show.
Now we can leverage on the `bindAdapter` to auto control the visibility base on other adapter itemCount.